### PR TITLE
Add destination prefix option to publish task

### DIFF
--- a/publish/src/main/java/com/indix/gocd/s3publish/PublishTask.java
+++ b/publish/src/main/java/com/indix/gocd/s3publish/PublishTask.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.indix.gocd.utils.Constants.SOURCEDESTINATIONS;
+import static com.indix.gocd.utils.Constants.DESTINATION_PREFIX;
 import static com.indix.gocd.utils.utils.Lists.foreach;
 import static org.apache.commons.lang3.StringUtils.trim;
 
@@ -30,6 +31,7 @@ public class PublishTask implements Task {
     public TaskConfig config() {
         TaskConfig taskConfig = new TaskConfig();
         taskConfig.addProperty(SOURCEDESTINATIONS);
+        taskConfig.addProperty(DESTINATION_PREFIX);
         return taskConfig;
     }
 

--- a/publish/src/main/resources/views/task.template.html
+++ b/publish/src/main/resources/views/task.template.html
@@ -26,6 +26,17 @@
     <span class="form_error" ng-show="GOINPUTNAME[sourceDestinations].$error.server">{{ GOINPUTNAME[sourceDestinations].$error.server }}</span>
 </div>
 <div class="form_item_block">
+  <label for="destinationPrefix">Destination Prefix</label>
+  <input id="destinationPrefix" type="text" ng-model="destinationPrefix" />
+  <span class="form_error" ng-show="GOINPUTNAME[destinationPrefix].$error.server">{{ GOINPUTNAME[destinationPrefix].$error.server }}</span>
+</div>
+<div class="form_item_block">
+    <p>
+        <span ng-show="destinationPrefix">Your artifact destinations will be prefixed with {{destinationPrefix}}</span>
+        <span ng-show="!destinationPrefix">Your artifact destinations will be prefixed with pipeline/stage/job/pipelineCounter.stageCounter</span>
+    </p>
+</div>
+<div class="form_item_block">
     <p class="required">Make sure AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, GO_ARTIFACTS_S3_BUCKET and GO_SERVER_DASHBOARD_URL environment variables are present with appropriate values on any of pipeline / Go Environments / on all agent machines. </p>
 </div>
 <script type="text/javascript">

--- a/publish/src/test/java/com/indix/gocd/s3publish/PublishExecutorTest.java
+++ b/publish/src/test/java/com/indix/gocd/s3publish/PublishExecutorTest.java
@@ -219,17 +219,17 @@ public class PublishExecutorTest {
                 .with(COMPLETED, COMPLETED)
                 .build();
         assertThat(metadataPutRequest.getMetadata().getUserMetadata(), is(expectedUserMetadata));
-        assertThat(metadataPutRequest.getKey(), is("/"));
+        assertThat(metadataPutRequest.getKey(), is(""));
 
         PutObjectRequest readmePutRequest = allPutObjectRequests.get(0);
         assertThat(readmePutRequest.getBucketName(), is("testS3Bucket"));
-        assertThat(readmePutRequest.getKey(), is("/README.md"));
+        assertThat(readmePutRequest.getKey(), is("README.md"));
         assertNull(readmePutRequest.getMetadata());
 
         PutObjectRequest jarPutRequest = allPutObjectRequests.get(1);
         assertNull(jarPutRequest.getMetadata());
         assertThat(jarPutRequest.getBucketName(), is("testS3Bucket"));
-        assertThat(jarPutRequest.getKey(), is("/s3publish-0.1.31.jar"));
+        assertThat(jarPutRequest.getKey(), is("s3publish-0.1.31.jar"));
         assertNull(jarPutRequest.getMetadata());
     }
 

--- a/publish/src/test/java/com/indix/gocd/s3publish/PublishExecutorTest.java
+++ b/publish/src/test/java/com/indix/gocd/s3publish/PublishExecutorTest.java
@@ -138,16 +138,7 @@ public class PublishExecutorTest {
 
         assertTrue(executionResult.isSuccessful());
 
-        final List<PutObjectRequest> allPutObjectRequests = getPutObjectRequests(mockClient, 3);
-
-        PutObjectRequest metadataPutRequest = allPutObjectRequests.get(2);
-        Map<String, String> expectedUserMetadata = Maps.<String, String>builder()
-                .with(METADATA_USER, "Krishna")
-                .with(METADATA_TRACEBACK_URL, "http://go.server:8153/go/tab/build/detail/pipeline/pipelineCounter/stage/stageCounter/job")
-                .with(COMPLETED, COMPLETED)
-                .build();
-        assertThat(metadataPutRequest.getMetadata().getUserMetadata(), is(expectedUserMetadata));
-        assertThat(metadataPutRequest.getKey(), is("destinationPrefix/"));
+        final List<PutObjectRequest> allPutObjectRequests = getPutObjectRequests(mockClient, 2);
 
         PutObjectRequest readmePutRequest = allPutObjectRequests.get(0);
         assertThat(readmePutRequest.getBucketName(), is("testS3Bucket"));
@@ -174,16 +165,7 @@ public class PublishExecutorTest {
 
         assertTrue(executionResult.isSuccessful());
 
-        final List<PutObjectRequest> allPutObjectRequests = getPutObjectRequests(mockClient, 3);
-
-        PutObjectRequest metadataPutRequest = allPutObjectRequests.get(2);
-        Map<String, String> expectedUserMetadata = Maps.<String, String>builder()
-                .with(METADATA_USER, "Krishna")
-                .with(METADATA_TRACEBACK_URL, "http://go.server:8153/go/tab/build/detail/pipeline/pipelineCounter/stage/stageCounter/job")
-                .with(COMPLETED, COMPLETED)
-                .build();
-        assertThat(metadataPutRequest.getMetadata().getUserMetadata(), is(expectedUserMetadata));
-        assertThat(metadataPutRequest.getKey(), is("test/pipelineCounter/"));
+        final List<PutObjectRequest> allPutObjectRequests = getPutObjectRequests(mockClient, 2);
 
         PutObjectRequest readmePutRequest = allPutObjectRequests.get(0);
         assertThat(readmePutRequest.getBucketName(), is("testS3Bucket"));
@@ -210,16 +192,7 @@ public class PublishExecutorTest {
 
         assertTrue(executionResult.isSuccessful());
 
-        final List<PutObjectRequest> allPutObjectRequests = getPutObjectRequests(mockClient, 3);
-
-        PutObjectRequest metadataPutRequest = allPutObjectRequests.get(2);
-        Map<String, String> expectedUserMetadata = Maps.<String, String>builder()
-                .with(METADATA_USER, "Krishna")
-                .with(METADATA_TRACEBACK_URL, "http://go.server:8153/go/tab/build/detail/pipeline/pipelineCounter/stage/stageCounter/job")
-                .with(COMPLETED, COMPLETED)
-                .build();
-        assertThat(metadataPutRequest.getMetadata().getUserMetadata(), is(expectedUserMetadata));
-        assertThat(metadataPutRequest.getKey(), is(""));
+        final List<PutObjectRequest> allPutObjectRequests = getPutObjectRequests(mockClient, 2);
 
         PutObjectRequest readmePutRequest = allPutObjectRequests.get(0);
         assertThat(readmePutRequest.getBucketName(), is("testS3Bucket"));

--- a/publish/src/test/java/com/indix/gocd/s3publish/PublishExecutorTest.java
+++ b/publish/src/test/java/com/indix/gocd/s3publish/PublishExecutorTest.java
@@ -74,25 +74,34 @@ public class PublishExecutorTest {
     }
 
     @Test
-    public void shouldUploadALocalFileToS3() {
-        Map<String, String> mockVariables = mockEnvironmentVariables.build();
+    public void shouldGetDisplayMessageAfterUpload() {
         AmazonS3Client mockClient = mockClient();
-        doReturn(mockClient).when(publishExecutor).s3Client(any(GoEnvironment.class));
-        when(config.getValue(SOURCEDESTINATIONS)).thenReturn("[{\"source\": \"target/*\", \"destination\": \"\"}]");
-        doReturn(new String[]{"README.md", "s3publish-0.1.31.jar"}).when(publishExecutor).parseSourcePath(anyString(), anyString());
 
-        ExecutionResult executionResult = publishExecutor.execute(config, mockContext(mockVariables));
+        ExecutionResult executionResult = executeMockPublish(
+                mockClient,
+                "[{\"source\": \"target/*\", \"destination\": \"\"}]",
+                "",
+                new String[]{"README.md"}
+        );
+
         assertTrue(executionResult.isSuccessful());
         assertThat(executionResult.getMessagesForDisplay(), is("Published all artifacts to S3"));
+    }
 
-        ArgumentCaptor<PutObjectRequest> putObjectRequestArgumentCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
-        verify(mockClient, times(3)).putObject(putObjectRequestArgumentCaptor.capture());
-        List<PutObjectRequest> allPutObjectRequests = putObjectRequestArgumentCaptor.getAllValues();
+    @Test
+    public void shouldUploadALocalFileToS3WithDefaultPrefix() {
+        AmazonS3Client mockClient = mockClient();
 
+        ExecutionResult executionResult = executeMockPublish(
+                mockClient,
+                "[{\"source\": \"target/*\", \"destination\": \"\"}]",
+                "",
+                new String[]{"README.md", "s3publish-0.1.31.jar"}
+        );
 
-        PutObjectRequest filePutRequest = allPutObjectRequests.get(0);
-        assertThat(filePutRequest.getBucketName(), is("testS3Bucket"));
-        assertThat(filePutRequest.getKey(), is("pipeline/stage/job/pipelineCounter.stageCounter/README.md"));
+        assertTrue(executionResult.isSuccessful());
+
+        final List<PutObjectRequest> allPutObjectRequests = getPutObjectRequests(mockClient, 3);
 
         PutObjectRequest metadataPutRequest = allPutObjectRequests.get(2);
         Map<String, String> expectedUserMetadata = Maps.<String, String>builder()
@@ -101,8 +110,8 @@ public class PublishExecutorTest {
                 .with(COMPLETED, COMPLETED)
                 .build();
         assertThat(metadataPutRequest.getMetadata().getUserMetadata(), is(expectedUserMetadata));
+        assertThat(metadataPutRequest.getKey(), is("pipeline/stage/job/pipelineCounter.stageCounter/"));
 
-        assertNull(filePutRequest.getMetadata());
         PutObjectRequest readmePutRequest = allPutObjectRequests.get(0);
         assertThat(readmePutRequest.getBucketName(), is("testS3Bucket"));
         assertThat(readmePutRequest.getKey(), is("pipeline/stage/job/pipelineCounter.stageCounter/README.md"));
@@ -115,6 +124,135 @@ public class PublishExecutorTest {
         assertNull(jarPutRequest.getMetadata());
     }
 
+
+    @Test
+    public void shouldUploadALocalFileToS3WithDestinationPrefix() {
+        AmazonS3Client mockClient = mockClient();
+
+        ExecutionResult executionResult = executeMockPublish(
+                mockClient,
+                "[{\"source\": \"target/*\", \"destination\": \"\"}]",
+                "destinationPrefix",
+                new String[]{"README.md", "s3publish-0.1.31.jar"}
+        );
+
+        assertTrue(executionResult.isSuccessful());
+
+        final List<PutObjectRequest> allPutObjectRequests = getPutObjectRequests(mockClient, 3);
+
+        PutObjectRequest metadataPutRequest = allPutObjectRequests.get(2);
+        Map<String, String> expectedUserMetadata = Maps.<String, String>builder()
+                .with(METADATA_USER, "Krishna")
+                .with(METADATA_TRACEBACK_URL, "http://go.server:8153/go/tab/build/detail/pipeline/pipelineCounter/stage/stageCounter/job")
+                .with(COMPLETED, COMPLETED)
+                .build();
+        assertThat(metadataPutRequest.getMetadata().getUserMetadata(), is(expectedUserMetadata));
+        assertThat(metadataPutRequest.getKey(), is("destinationPrefix/"));
+
+        PutObjectRequest readmePutRequest = allPutObjectRequests.get(0);
+        assertThat(readmePutRequest.getBucketName(), is("testS3Bucket"));
+        assertThat(readmePutRequest.getKey(), is("destinationPrefix/README.md"));
+        assertNull(readmePutRequest.getMetadata());
+
+        PutObjectRequest jarPutRequest = allPutObjectRequests.get(1);
+        assertNull(jarPutRequest.getMetadata());
+        assertThat(jarPutRequest.getBucketName(), is("testS3Bucket"));
+        assertThat(jarPutRequest.getKey(), is("destinationPrefix/s3publish-0.1.31.jar"));
+        assertNull(jarPutRequest.getMetadata());
+    }
+
+    @Test
+    public void shouldUploadALocalFileToS3WithDestinationPrefixUsingEnvVariable() {
+        AmazonS3Client mockClient = mockClient();
+
+        ExecutionResult executionResult = executeMockPublish(
+                mockClient,
+                "[{\"source\": \"target/*\", \"destination\": \"\"}]",
+                "test/${GO_PIPELINE_COUNTER}/",
+                new String[]{"README.md", "s3publish-0.1.31.jar"}
+        );
+
+        assertTrue(executionResult.isSuccessful());
+
+        final List<PutObjectRequest> allPutObjectRequests = getPutObjectRequests(mockClient, 3);
+
+        PutObjectRequest metadataPutRequest = allPutObjectRequests.get(2);
+        Map<String, String> expectedUserMetadata = Maps.<String, String>builder()
+                .with(METADATA_USER, "Krishna")
+                .with(METADATA_TRACEBACK_URL, "http://go.server:8153/go/tab/build/detail/pipeline/pipelineCounter/stage/stageCounter/job")
+                .with(COMPLETED, COMPLETED)
+                .build();
+        assertThat(metadataPutRequest.getMetadata().getUserMetadata(), is(expectedUserMetadata));
+        assertThat(metadataPutRequest.getKey(), is("test/pipelineCounter/"));
+
+        PutObjectRequest readmePutRequest = allPutObjectRequests.get(0);
+        assertThat(readmePutRequest.getBucketName(), is("testS3Bucket"));
+        assertThat(readmePutRequest.getKey(), is("test/pipelineCounter/README.md"));
+        assertNull(readmePutRequest.getMetadata());
+
+        PutObjectRequest jarPutRequest = allPutObjectRequests.get(1);
+        assertNull(jarPutRequest.getMetadata());
+        assertThat(jarPutRequest.getBucketName(), is("testS3Bucket"));
+        assertThat(jarPutRequest.getKey(), is("test/pipelineCounter/s3publish-0.1.31.jar"));
+        assertNull(jarPutRequest.getMetadata());
+    }
+
+    @Test
+    public void shouldUploadALocalFileToS3WithSlashDestinationPrefix() {
+        AmazonS3Client mockClient = mockClient();
+
+        ExecutionResult executionResult = executeMockPublish(
+                mockClient,
+                "[{\"source\": \"target/*\", \"destination\": \"\"}]",
+                "/",
+                new String[]{"README.md", "s3publish-0.1.31.jar"}
+        );
+
+        assertTrue(executionResult.isSuccessful());
+
+        final List<PutObjectRequest> allPutObjectRequests = getPutObjectRequests(mockClient, 3);
+
+        PutObjectRequest metadataPutRequest = allPutObjectRequests.get(2);
+        Map<String, String> expectedUserMetadata = Maps.<String, String>builder()
+                .with(METADATA_USER, "Krishna")
+                .with(METADATA_TRACEBACK_URL, "http://go.server:8153/go/tab/build/detail/pipeline/pipelineCounter/stage/stageCounter/job")
+                .with(COMPLETED, COMPLETED)
+                .build();
+        assertThat(metadataPutRequest.getMetadata().getUserMetadata(), is(expectedUserMetadata));
+        assertThat(metadataPutRequest.getKey(), is("/"));
+
+        PutObjectRequest readmePutRequest = allPutObjectRequests.get(0);
+        assertThat(readmePutRequest.getBucketName(), is("testS3Bucket"));
+        assertThat(readmePutRequest.getKey(), is("/README.md"));
+        assertNull(readmePutRequest.getMetadata());
+
+        PutObjectRequest jarPutRequest = allPutObjectRequests.get(1);
+        assertNull(jarPutRequest.getMetadata());
+        assertThat(jarPutRequest.getBucketName(), is("testS3Bucket"));
+        assertThat(jarPutRequest.getKey(), is("/s3publish-0.1.31.jar"));
+        assertNull(jarPutRequest.getMetadata());
+    }
+
+    private ExecutionResult executeMockPublish(final AmazonS3Client mockClient, String sourceDestinations, String destinationPrefix, String[] files) {
+        Map<String, String> mockVariables = mockEnvironmentVariables.build();
+
+        doReturn(mockClient).when(publishExecutor).s3Client(any(GoEnvironment.class));
+        when(config.getValue(SOURCEDESTINATIONS)).thenReturn(sourceDestinations);
+        when(config.getValue(DESTINATION_PREFIX)).thenReturn(destinationPrefix);
+        doReturn(files).when(publishExecutor).parseSourcePath(anyString(), anyString());
+
+        ExecutionResult executionResult = publishExecutor.execute(config, mockContext(mockVariables));
+
+        return executionResult;
+    }
+
+    private List<PutObjectRequest> getPutObjectRequests(AmazonS3Client mockClient, int expectedRequestsCount) {
+        ArgumentCaptor<PutObjectRequest> putObjectRequestArgumentCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(mockClient, times(expectedRequestsCount)).putObject(putObjectRequestArgumentCaptor.capture());
+        List<PutObjectRequest> allPutObjectRequests = putObjectRequestArgumentCaptor.getAllValues();
+
+        return allPutObjectRequests;
+    }
     private TaskExecutionContext mockContext(final Map<String, String> environmentMap) {
         return new MockTaskExecutionContext(environmentMap);
     }

--- a/utils/src/main/java/com/indix/gocd/utils/Constants.java
+++ b/utils/src/main/java/com/indix/gocd/utils/Constants.java
@@ -7,7 +7,10 @@ public class Constants {
 
     public static final String GO_ARTIFACTS_S3_BUCKET = "GO_ARTIFACTS_S3_BUCKET";
     public static final String GO_SERVER_DASHBOARD_URL = "GO_SERVER_DASHBOARD_URL";
+
     public static final String SOURCEDESTINATIONS = "sourceDestinations";
+    public static final String DESTINATION_PREFIX = "destinationPrefix";
+
     public static final String AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
     public static final String AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID";
 }

--- a/utils/src/main/java/com/indix/gocd/utils/GoEnvironment.java
+++ b/utils/src/main/java/com/indix/gocd/utils/GoEnvironment.java
@@ -1,7 +1,12 @@
 package com.indix.gocd.utils;
 
+import java.lang.StringBuffer;
+
 import java.util.HashMap;
 import java.util.Map;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static com.indix.gocd.utils.Constants.GO_SERVER_DASHBOARD_URL;
@@ -10,6 +15,7 @@ import static com.indix.gocd.utils.Constants.GO_SERVER_DASHBOARD_URL;
  * Wrapper around Go's Environment variables
  */
 public class GoEnvironment {
+    private Pattern envPat = Pattern.compile("\\$\\{(\\w+)\\}");
     private Map<String, String> environment = new HashMap<String, String>();
 
     public GoEnvironment() {
@@ -45,6 +51,22 @@ public class GoEnvironment {
 
     public String triggeredUser() {
         return get("GO_TRIGGER_USER");
+    }
+
+    public String replaceVariables(String str) {
+      Matcher m = envPat.matcher(str);
+
+      StringBuffer sb = new StringBuffer();
+      while (m.find()) {
+        String replacement = get(m.group(1));
+        if(replacement != null) {
+          m.appendReplacement(sb, replacement);
+        }
+      }
+
+      m.appendTail(sb);
+
+      return sb.toString();
     }
 
     /**

--- a/utils/src/test/java/com/indix/gocd/utils/GoEnvironmentTest.java
+++ b/utils/src/test/java/com/indix/gocd/utils/GoEnvironmentTest.java
@@ -38,4 +38,19 @@ public class GoEnvironmentTest {
         assertThat(goEnvironment.artifactsLocationTemplate(), is("s3-publish-test/build-and-publish/publish/20.1"));
     }
 
+    @Test
+    public void shouldReplaceWithEnvVariables() {
+        final String envTestTemplate = "COUNT:${GO_STAGE_COUNTER} Name:${GO_STAGE_NAME} COUNT2:${GO_STAGE_COUNTER}";
+        final String replaced = goEnvironment.replaceVariables(envTestTemplate);
+
+        assertThat(replaced, is("COUNT:1 Name:build-and-publish COUNT2:1"));
+    }
+
+    @Test
+    public void shouldNotReplaceUnknownEnvVariables() {
+        final String envTestTemplate = "COUNT:${GO_STAGE_COUNTER} ${DOESNT_EXIST}";
+        final String replaced = goEnvironment.replaceVariables(envTestTemplate);
+
+        assertThat(replaced, is("COUNT:1 ${DOESNT_EXIST}"));
+    }
 }


### PR DESCRIPTION
Adds a destination prefix option to the publish task to enable users to specify where artifacts are uploaded to on s3 more precisely. Resolves issue #10.