### PR TITLE
Allow S3 Fetch config with dashes in the name to still work

### DIFF
--- a/fetch/src/main/java/com/indix/gocd/s3fetch/FetchConfig.java
+++ b/fetch/src/main/java/com/indix/gocd/s3fetch/FetchConfig.java
@@ -20,8 +20,8 @@ public class FetchConfig {
         this.env = new GoEnvironment();
         env.putAll(context.environment().asMap());
 
-        String repoName = config.getValue(FetchTask.REPO).toUpperCase();
-        String packageName = config.getValue(FetchTask.PACKAGE).toUpperCase();
+        String repoName = config.getValue(FetchTask.REPO).toUpperCase().replaceAll("-", "_");
+        String packageName = config.getValue(FetchTask.PACKAGE).toUpperCase().replaceAll("-", "_");
         this.materialLabel = env.get(String.format("GO_PACKAGE_%s_%s_LABEL", repoName, packageName));
         this.pipeline = env.get(String.format("GO_PACKAGE_%s_%s_PIPELINE_NAME", repoName, packageName));
         this.stage = env.get(String.format("GO_PACKAGE_%s_%s_STAGE_NAME", repoName, packageName));

--- a/fetch/src/test/java/com/indix/gocd/s3fetch/FetchConfigTest.java
+++ b/fetch/src/test/java/com/indix/gocd/s3fetch/FetchConfigTest.java
@@ -132,6 +132,26 @@ public class FetchConfigTest {
         assertThat(validationResult.getMessages(), Matchers.<List<String>>is(messages));
     }
 
+    @Test
+    public void shouldAllowFetchTaskVariablesWithDashesInTheName() throws Exception {
+        config = mock(TaskConfig.class);
+        when(config.getValue(FetchTask.REPO)).thenReturn("repo-with-dash");
+        when(config.getValue(FetchTask.PACKAGE)).thenReturn("package-with-dash");
+        mockEnvironmentVariables = Maps.<String, String>builder()
+                .with(AWS_SECRET_ACCESS_KEY, secretKey)
+                .with(AWS_ACCESS_KEY_ID, accessId)
+                .with(GO_ARTIFACTS_S3_BUCKET, bucket)
+                .with("GO_PACKAGE_REPO_WITH_DASH_PACKAGE_WITH_DASH_LABEL", "20.1")
+                .with("GO_REPO_REPO_WITH_DASH_PACKAGE_WITH_DASH_S3_BUCKET", bucket)
+                .with("GO_PACKAGE_REPO_WITH_DASH_PACKAGE_WITH_DASH_PIPELINE_NAME", "TestPublish")
+                .with("GO_PACKAGE_REPO_WITH_DASH_PACKAGE_WITH_DASH_STAGE_NAME", "defaultStage")
+                .with("GO_PACKAGE_REPO_WITH_DASH_PACKAGE_WITH_DASH_JOB_NAME", "defaultJob");
+
+        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()));
+        ValidationResult validationResult = fetchConfig.validate();
+        assertTrue(validationResult.isSuccessful());
+    }
+
     private TaskExecutionContext mockContext(final Map<String, String> environmentMap) {
         return new MockTaskExecutionContext(environmentMap);
     }


### PR DESCRIPTION
When a S3 Fetch config repo or package name contains a dash in the name, the material environment variables (GO_PACKAGE_*) are saved as an underscore (bash restriction). This can lead to confusion when the fetch configs 'appear' correct however the S3 Fetch plugin complains about the configuration.

 