### PR TITLE
Unset AWS vars so unit tests pass

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+export AWS_ACCESS_KEY_ID=
+export AWS_SECRET_ACCESS_KEY=
+
 sbt clean editsource:edit assembly


### PR DESCRIPTION
When AWS environment variables are set SBT script fails.   This is very annoying problem when trying to build on go.cd agent that has these variables set because s3-artifacts plugin requires them.

Just unsetting variables in build script solves the problem.

