### PR TITLE
Proper fix for #19

### DIFF
--- a/fetch/src/test/java/com/indix/gocd/s3fetch/FetchConfigTest.java
+++ b/fetch/src/test/java/com/indix/gocd/s3fetch/FetchConfigTest.java
@@ -82,7 +82,7 @@ public class FetchConfigTest {
 
     @Test
     public void shouldNotBeValidIfAWSSecretAccessKeyNotPresent() {
-        fetchConfig = new FetchConfig(config, mockContext( mockEnvironmentVariables.remove(AWS_SECRET_ACCESS_KEY).build()));
+        fetchConfig = new FetchConfig(config, mockContext( mockEnvironmentVariables.with(AWS_SECRET_ACCESS_KEY, "").build()));
         ValidationResult validationResult = fetchConfig.validate();
         assertFalse(validationResult.isSuccessful());
         ArrayList<String> messages = new ArrayList<String>();
@@ -92,7 +92,7 @@ public class FetchConfigTest {
 
     @Test
     public void shouldNotBeValidIfAWSAccessKeyIdNotPresent() {
-        fetchConfig = new FetchConfig(config, mockContext( mockEnvironmentVariables.remove(AWS_ACCESS_KEY_ID).build()));
+        fetchConfig = new FetchConfig(config, mockContext( mockEnvironmentVariables.with(AWS_ACCESS_KEY_ID, "").build()));
         ValidationResult validationResult = fetchConfig.validate();
         assertFalse(validationResult.isSuccessful());
         ArrayList<String> messages = new ArrayList<String>();
@@ -102,7 +102,7 @@ public class FetchConfigTest {
 
     @Test
     public void shouldNotBeValidIfS3BucketNotPresent() {
-        fetchConfig = new FetchConfig(config, mockContext( mockEnvironmentVariables.remove(GO_ARTIFACTS_S3_BUCKET).build()));
+        fetchConfig = new FetchConfig(config, mockContext( mockEnvironmentVariables.with(GO_ARTIFACTS_S3_BUCKET, "").build()));
         ValidationResult validationResult = fetchConfig.validate();
         assertFalse(validationResult.isSuccessful());
         ArrayList<String> messages = new ArrayList<String>();

--- a/fetch/src/test/java/com/indix/gocd/s3fetch/FetchExecutorTest.java
+++ b/fetch/src/test/java/com/indix/gocd/s3fetch/FetchExecutorTest.java
@@ -50,7 +50,7 @@ public class FetchExecutorTest {
 
     @Test
     public void shouldBeFailureIfFetchConfigNotValid() {
-        Map<String, String> mockVariables = mockEnvironmentVariables.remove(AWS_ACCESS_KEY_ID).build();
+        Map<String, String> mockVariables = mockEnvironmentVariables.with(AWS_ACCESS_KEY_ID, "").build();
 
         ExecutionResult executionResult = fetchExecutor.execute(config, mockContext(mockVariables));
         assertFalse(executionResult.isSuccessful());

--- a/publish/src/test/java/com/indix/gocd/s3publish/PublishExecutorTest.java
+++ b/publish/src/test/java/com/indix/gocd/s3publish/PublishExecutorTest.java
@@ -48,7 +48,7 @@ public class PublishExecutorTest {
 
     @Test
     public void shouldThrowIfAWS_ACCESS_KEY_IDNotPresent() {
-        Map<String, String> mockVariables = mockEnvironmentVariables.remove(AWS_ACCESS_KEY_ID).build();
+        Map<String, String> mockVariables = mockEnvironmentVariables.with(AWS_ACCESS_KEY_ID, "").build();
 
         ExecutionResult executionResult = publishExecutor.execute(config, mockContext(mockVariables));
         assertFalse(executionResult.isSuccessful());
@@ -57,7 +57,7 @@ public class PublishExecutorTest {
 
     @Test
     public void shouldThrowIfAWS_SECRET_ACCESS_KEYNotPresent() {
-        Map<String, String> mockVariables = mockEnvironmentVariables.remove(AWS_SECRET_ACCESS_KEY).build();
+        Map<String, String> mockVariables = mockEnvironmentVariables.with(AWS_SECRET_ACCESS_KEY, "").build();
 
         ExecutionResult executionResult = publishExecutor.execute(config, mockContext(mockVariables));
         assertFalse(executionResult.isSuccessful());
@@ -66,7 +66,7 @@ public class PublishExecutorTest {
 
     @Test
     public void shouldThrowIfGO_ARTIFACTS_S3_BUCKETNotPresent() {
-        Map<String, String> mockVariables = mockEnvironmentVariables.remove(GO_ARTIFACTS_S3_BUCKET).build();
+        Map<String, String> mockVariables = mockEnvironmentVariables.with(GO_ARTIFACTS_S3_BUCKET, "").build();
 
         ExecutionResult executionResult = publishExecutor.execute(config, mockContext(mockVariables));
         assertFalse(executionResult.isSuccessful());


### PR DESCRIPTION
Actually we remove certain env variables from the mock context environment variables but our GoEnvironment always appends the values from System.getEnv. The proper fix would be to empty the values instead of just removing them. 