### PR TITLE
Adds the ability to use IAM roles from EC2 instances for credentials

### DIFF
--- a/fetch/src/main/java/com/indix/gocd/s3fetch/FetchConfig.java
+++ b/fetch/src/main/java/com/indix/gocd/s3fetch/FetchConfig.java
@@ -30,8 +30,10 @@ public class FetchConfig {
 
     public ValidationResult validate() {
         ValidationResult validationResult = new ValidationResult();
-        if (env.isAbsent(AWS_ACCESS_KEY_ID)) validationResult.addError(envNotFound(AWS_ACCESS_KEY_ID));
-        if (env.isAbsent(AWS_SECRET_ACCESS_KEY)) validationResult.addError(envNotFound(AWS_SECRET_ACCESS_KEY));
+        if (env.isAbsent(AWS_USE_IAM_ROLE)) {
+            if (env.isAbsent(AWS_ACCESS_KEY_ID)) validationResult.addError(envNotFound(AWS_ACCESS_KEY_ID));
+            if (env.isAbsent(AWS_SECRET_ACCESS_KEY)) validationResult.addError(envNotFound(AWS_SECRET_ACCESS_KEY));
+        }
         if (env.isAbsent(GO_ARTIFACTS_S3_BUCKET)) validationResult.addError(envNotFound(GO_ARTIFACTS_S3_BUCKET));
         if (StringUtils.isNullOrEmpty(materialLabel))
             validationResult.addError(new ValidationError("Please check Repository name or Package name configuration. Also ensure that the appropriate S3 material is configured for the pipeline."));
@@ -44,6 +46,10 @@ public class FetchConfig {
         String pipelineCounter = counters[0];
         String stageCounter = counters[1];
         return env.artifactsLocationTemplate(pipeline, stage, job, pipelineCounter, stageCounter);
+    }
+
+    public boolean hasAWSUseIamRole() {
+        return env.has(AWS_USE_IAM_ROLE);
     }
 
     public String getAWSAccessKeyId() {

--- a/fetch/src/main/java/com/indix/gocd/s3fetch/FetchExecutor.java
+++ b/fetch/src/main/java/com/indix/gocd/s3fetch/FetchExecutor.java
@@ -1,6 +1,7 @@
 package com.indix.gocd.s3fetch;
 
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.indix.gocd.utils.store.S3ArtifactStore;
 import com.thoughtworks.go.plugin.api.logging.Logger;
@@ -62,8 +63,13 @@ public class FetchExecutor implements TaskExecutor {
     }
 
     public AmazonS3Client s3Client(FetchConfig config) {
-        return new AmazonS3Client(new BasicAWSCredentials(config.getAWSAccessKeyId(), config.getAWSSecretAccessKey()));
+        AmazonS3Client client = null;
+        if (config.hasAWSUseIamRole()) {
+            client = new AmazonS3Client(new InstanceProfileCredentialsProvider());
+        } else {
+            client = new AmazonS3Client(new BasicAWSCredentials(config.getAWSAccessKeyId(), config.getAWSSecretAccessKey()));
+        }
+        return client;
     }
 
 }
-

--- a/fetch/src/main/resources/views/task.template.html
+++ b/fetch/src/main/resources/views/task.template.html
@@ -14,5 +14,5 @@
   <span class="form_error" ng-show="GOINPUTNAME[Destination].$error.server">{{ GOINPUTNAME[Destination].$error.server }}</span>
 </div>
 <div class="form_item_block">
-    <p class="required">Make sure AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID and GO_ARTIFACTS_S3_BUCKET environment variables are present with appropriate values on any of pipeline / Go Environments / on all agent machines. </p>
+    <p class="required">Make sure either AWS_USE_IAM_ROLE or AWS_SECRET_ACCESS_KEY + AWS_ACCESS_KEY_ID and GO_ARTIFACTS_S3_BUCKET environment variables are present with appropriate values on any of pipeline / Go Environments / on all agent machines. </p>
 </div>

--- a/publish/src/main/java/com/indix/gocd/s3publish/utils/ManuallyPublish.java
+++ b/publish/src/main/java/com/indix/gocd/s3publish/utils/ManuallyPublish.java
@@ -23,7 +23,8 @@ import java.util.Map;
 Utility to manually publish an artifact (if required) without being in Go.
 
 Run this Task with the following ENV variables
-- AWS_ACCESS_KEY_ID
+- AWS_USE_IAM_ROLE OR
+- AWS_ACCESS_KEY_ID AND
 - AWS_SECRET_ACCESS_KEY
 - GO_ARTIFACTS_S3_BUCKET
 - GO_SERVER_URL

--- a/publish/src/main/resources/views/task.template.html
+++ b/publish/src/main/resources/views/task.template.html
@@ -37,7 +37,7 @@
     </p>
 </div>
 <div class="form_item_block">
-    <p class="required">Make sure AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, GO_ARTIFACTS_S3_BUCKET and GO_SERVER_DASHBOARD_URL environment variables are present with appropriate values on any of pipeline / Go Environments / on all agent machines. </p>
+    <p class="required">Make sure either AWS_USE_IAM_ROLE or AWS_SECRET_ACCESS_KEY + AWS_ACCESS_KEY_ID, GO_ARTIFACTS_S3_BUCKET and GO_SERVER_DASHBOARD_URL environment variables are present with appropriate values on any of pipeline / Go Environments / on all agent machines. </p>
 </div>
 <script type="text/javascript">
     jQuery(document).ready(function() {

--- a/utils/src/main/java/com/indix/gocd/utils/Constants.java
+++ b/utils/src/main/java/com/indix/gocd/utils/Constants.java
@@ -13,4 +13,5 @@ public class Constants {
 
     public static final String AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
     public static final String AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID";
+    public static final String AWS_USE_IAM_ROLE = "AWS_USE_IAM_ROLE";
 }


### PR DESCRIPTION
When using GOCD in AWS it's best practice to avoid keys and use an IAM role attached to the machine itself, this change will enable that functionality.