### PR TITLE
Features/issue24 turning on iam role cannot be disabled

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,28 @@
+WHERE choco
+IF %ERRORLEVEL% NEQ 0 %PS% -NoProfile -ExecutionPolicy unrestricted -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%systemdrive%\ProgramData\chocolatey\bin
+choco install sbt --acceptlicense -y
+WHERE sbt
+IF %ERRORLEVEL% NEQ 0 SET PATH=%PATH%;%systemdrive%\Program Files (x86)\sbt\bin
+choco install "\\columbus\sw_share\DEPARTMENT\SD Software\Java\jdk8.8.0.66.nupkg" --acceptlicense -y
+
+WHERE sbt
+IF %ERRORLEVEL% EQU 0 GOTO sbtgood:
+echo ERROR: cannot find sbt
+exit /b 1
+
+:sbtgood
+WHERE java
+IF %ERRORLEVEL% NEQ 0 SET PATH=%PATH%;%systemdrive%\Program Files\Java\jdk1.8.0_66\bin
+
+WHERE java
+IF %ERRORLEVEL% EQU 0 GOTO javagood:
+echo ERROR: cannot find java
+exit /b 1
+
+:javagood
+call sbt clean editsource:edit assembly
+
+md Deploy
+copy .\fetch\target\s3fetch-*.jar .\Deploy
+copy .\material\target\s3material-*.jar .\Deploy
+copy .\publish\target\s3publish-*.jar .\Deploy

--- a/build.bat
+++ b/build.bat
@@ -21,6 +21,7 @@ exit /b 1
 
 :javagood
 call sbt clean editsource:edit assembly
+IF %ERRORLEVEL% NEQ 0 exit /b 1
 
 md Deploy
 copy .\fetch\target\s3fetch-*.jar .\Deploy

--- a/fetch/src/main/java/com/indix/gocd/s3fetch/FetchConfig.java
+++ b/fetch/src/main/java/com/indix/gocd/s3fetch/FetchConfig.java
@@ -2,10 +2,16 @@ package com.indix.gocd.s3fetch;
 
 import com.amazonaws.util.StringUtils;
 import com.indix.gocd.utils.GoEnvironment;
+import com.thoughtworks.go.plugin.api.logging.Logger;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationError;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.api.task.TaskConfig;
 import com.thoughtworks.go.plugin.api.task.TaskExecutionContext;
+import org.apache.commons.lang3.BooleanUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static com.indix.gocd.utils.Constants.*;
 
@@ -35,7 +41,7 @@ public class FetchConfig {
 
     public ValidationResult validate() {
         ValidationResult validationResult = new ValidationResult();
-        if (env.isAbsent(AWS_USE_IAM_ROLE)) {
+        if (!hasAWSUseIamRole()) {
             if (env.isAbsent(AWS_ACCESS_KEY_ID)) validationResult.addError(envNotFound(AWS_ACCESS_KEY_ID));
             if (env.isAbsent(AWS_SECRET_ACCESS_KEY)) validationResult.addError(envNotFound(AWS_SECRET_ACCESS_KEY));
         }
@@ -53,8 +59,21 @@ public class FetchConfig {
         return env.artifactsLocationTemplate(pipeline, stage, job, pipelineCounter, stageCounter);
     }
 
+    private static final List<String> validUseIamRoleValues = new ArrayList<String>(Arrays.asList("true", "false", "yes", "no", "on", "off"));
     public boolean hasAWSUseIamRole() {
-        return env.has(AWS_USE_IAM_ROLE);
+        if (!env.has(AWS_USE_IAM_ROLE)) {
+            return false;
+        }
+
+        String useIamRoleValue = env.get(AWS_USE_IAM_ROLE);
+        Boolean result = BooleanUtils.toBooleanObject(useIamRoleValue);
+        if (result == null) {
+            throw new IllegalArgumentException(getEnvInvalidFormatMessage(AWS_USE_IAM_ROLE,
+                    useIamRoleValue, validUseIamRoleValues.toString()));
+        }
+        else {
+            return result.booleanValue();
+        }
     }
 
     public String getAWSAccessKeyId() {
@@ -71,5 +90,11 @@ public class FetchConfig {
 
     private ValidationError envNotFound(String environmentVariable) {
         return new ValidationError(environmentVariable, String.format("%s environment variable not present", environmentVariable));
+    }
+
+    private String getEnvInvalidFormatMessage(String environmentVariable, String value, String expected){
+        return String.format(
+                "Unexpected value in %s environment variable; was %s, but expected one of the following %s",
+                environmentVariable, value, expected);
     }
 }

--- a/fetch/src/main/java/com/indix/gocd/s3fetch/FetchConfig.java
+++ b/fetch/src/main/java/com/indix/gocd/s3fetch/FetchConfig.java
@@ -16,8 +16,13 @@ public class FetchConfig {
     private final String job;
     private GoEnvironment env;
 
-    public FetchConfig(TaskConfig config, TaskExecutionContext context) {
-        this.env = new GoEnvironment();
+    public FetchConfig(TaskConfig config, TaskExecutionContext context)
+    {
+        this(config, context, new GoEnvironment());
+    }
+
+    public FetchConfig(TaskConfig config, TaskExecutionContext context, GoEnvironment goEnvironment) {
+        this.env = goEnvironment;
         env.putAll(context.environment().asMap());
 
         String repoName = config.getValue(FetchTask.REPO).toUpperCase().replaceAll("-", "_");

--- a/fetch/src/main/java/com/indix/gocd/s3fetch/FetchExecutor.java
+++ b/fetch/src/main/java/com/indix/gocd/s3fetch/FetchExecutor.java
@@ -20,7 +20,7 @@ public class FetchExecutor implements TaskExecutor {
 
     @Override
     public ExecutionResult execute(TaskConfig config, final TaskExecutionContext context) {
-        final FetchConfig fetchConfig = new FetchConfig(config, context);
+        final FetchConfig fetchConfig = getFetchConfig(config, context);
 
         ValidationResult validationResult = fetchConfig.validate();
         if(!validationResult.isSuccessful()) {
@@ -72,4 +72,7 @@ public class FetchExecutor implements TaskExecutor {
         return client;
     }
 
+    public FetchConfig getFetchConfig(TaskConfig config, TaskExecutionContext context) {
+        return new FetchConfig(config, context);
+    }
 }

--- a/fetch/src/test/java/com/indix/gocd/s3fetch/FetchConfigTest.java
+++ b/fetch/src/test/java/com/indix/gocd/s3fetch/FetchConfigTest.java
@@ -1,5 +1,6 @@
 package com.indix.gocd.s3fetch;
 
+import com.indix.gocd.utils.GoEnvironment;
 import com.indix.gocd.utils.mocks.MockTaskExecutionContext;
 import com.indix.gocd.utils.utils.Maps;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
@@ -10,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -26,6 +28,7 @@ public class FetchConfigTest {
     Maps.MapBuilder<String, String> mockEnvironmentVariables;
     private TaskConfig config;
     private FetchConfig fetchConfig;
+    private GoEnvironment goEnvironmentForTest;
     private final String secretKey = "secretKey";
     private final String accessId = "accessId";
 
@@ -43,46 +46,49 @@ public class FetchConfigTest {
                 .with("GO_PACKAGE_GOCD_TESTPUBLISHS3ARTIFACTS_PIPELINE_NAME", "TestPublish")
                 .with("GO_PACKAGE_GOCD_TESTPUBLISHS3ARTIFACTS_STAGE_NAME", "defaultStage")
                 .with("GO_PACKAGE_GOCD_TESTPUBLISHS3ARTIFACTS_JOB_NAME", "defaultJob");
+        goEnvironmentForTest = new GoEnvironment(new HashMap<String,String>());
+
     }
 
     @Test
     public void shouldGetAWSSecretAccessKey() {
-        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()));
+        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()),goEnvironmentForTest);
         String awsSecretAccessKey = fetchConfig.getAWSSecretAccessKey();
         assertThat(awsSecretAccessKey, is(secretKey));
     }
 
     @Test
     public void shouldGetAWSAccessKeyId() {
-        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()));
+        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()),goEnvironmentForTest);
         String awsSecretAccessKey = fetchConfig.getAWSAccessKeyId();
         assertThat(awsSecretAccessKey, is(accessId));
     }
 
     @Test
     public void shouldS3Bucket() {
-        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()));
+        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()),goEnvironmentForTest);
         String awsSecretAccessKey = fetchConfig.getS3Bucket();
         assertThat(awsSecretAccessKey, is(bucket));
     }
 
     @Test
     public void shouldGetArtifactLocation() {
-        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()));
+        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()),goEnvironmentForTest);
         String location = fetchConfig.getArtifactsLocationTemplate();
         assertThat(location, is("TestPublish/defaultStage/defaultJob/20.1"));
     }
 
     @Test
     public void shouldBeValid() {
-        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()));
+        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()),goEnvironmentForTest);
         ValidationResult validationResult = fetchConfig.validate();
         assertTrue(validationResult.isSuccessful());
     }
 
     @Test
     public void shouldNotBeValidIfAWSSecretAccessKeyNotPresent() {
-        fetchConfig = new FetchConfig(config, mockContext( mockEnvironmentVariables.with(AWS_SECRET_ACCESS_KEY, "").build()));
+        fetchConfig = new FetchConfig(config, mockContext( mockEnvironmentVariables.with(AWS_SECRET_ACCESS_KEY, "").build()),
+                goEnvironmentForTest);
         ValidationResult validationResult = fetchConfig.validate();
         assertFalse(validationResult.isSuccessful());
         ArrayList<String> messages = new ArrayList<String>();
@@ -92,7 +98,8 @@ public class FetchConfigTest {
 
     @Test
     public void shouldNotBeValidIfAWSAccessKeyIdNotPresent() {
-        fetchConfig = new FetchConfig(config, mockContext( mockEnvironmentVariables.with(AWS_ACCESS_KEY_ID, "").build()));
+        fetchConfig = new FetchConfig(config, mockContext( mockEnvironmentVariables.with(AWS_ACCESS_KEY_ID, "").build()),
+                goEnvironmentForTest);
         ValidationResult validationResult = fetchConfig.validate();
         assertFalse(validationResult.isSuccessful());
         ArrayList<String> messages = new ArrayList<String>();
@@ -102,7 +109,8 @@ public class FetchConfigTest {
 
     @Test
     public void shouldNotBeValidIfS3BucketNotPresent() {
-        fetchConfig = new FetchConfig(config, mockContext( mockEnvironmentVariables.with(GO_ARTIFACTS_S3_BUCKET, "").build()));
+        fetchConfig = new FetchConfig(config, mockContext( mockEnvironmentVariables.with(GO_ARTIFACTS_S3_BUCKET, "").build()),
+                goEnvironmentForTest);
         ValidationResult validationResult = fetchConfig.validate();
         assertFalse(validationResult.isSuccessful());
         ArrayList<String> messages = new ArrayList<String>();
@@ -113,7 +121,7 @@ public class FetchConfigTest {
     @Test
     public void shouldNotBeValidIfRepoConfigIsNotValid() {
         when(config.getValue(FetchTask.REPO)).thenReturn("Wrong");
-        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()));
+        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()),goEnvironmentForTest);
         ValidationResult validationResult = fetchConfig.validate();
         assertFalse(validationResult.isSuccessful());
         ArrayList<String> messages = new ArrayList<String>();
@@ -124,7 +132,7 @@ public class FetchConfigTest {
     @Test
     public void shouldNotBeValidIfPackageConfigIsNotValid() {
         when(config.getValue(FetchTask.PACKAGE)).thenReturn("Wrong");
-        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()));
+        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()),goEnvironmentForTest);
         ValidationResult validationResult = fetchConfig.validate();
         assertFalse(validationResult.isSuccessful());
         ArrayList<String> messages = new ArrayList<String>();
@@ -147,7 +155,7 @@ public class FetchConfigTest {
                 .with("GO_PACKAGE_REPO_WITH_DASH_PACKAGE_WITH_DASH_STAGE_NAME", "defaultStage")
                 .with("GO_PACKAGE_REPO_WITH_DASH_PACKAGE_WITH_DASH_JOB_NAME", "defaultJob");
 
-        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()));
+        fetchConfig = new FetchConfig(config, mockContext(mockEnvironmentVariables.build()),goEnvironmentForTest);
         ValidationResult validationResult = fetchConfig.validate();
         assertTrue(validationResult.isSuccessful());
     }

--- a/fetch/src/test/java/com/indix/gocd/s3fetch/FetchExecutorTest.java
+++ b/fetch/src/test/java/com/indix/gocd/s3fetch/FetchExecutorTest.java
@@ -3,6 +3,7 @@ package com.indix.gocd.s3fetch;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.indix.gocd.utils.GoEnvironment;
 import com.indix.gocd.utils.mocks.MockTaskExecutionContext;
 import com.indix.gocd.utils.store.S3ArtifactStore;
 import com.indix.gocd.utils.utils.Maps;
@@ -12,6 +13,7 @@ import com.thoughtworks.go.plugin.api.task.TaskExecutionContext;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.indix.gocd.utils.Constants.*;
@@ -51,8 +53,12 @@ public class FetchExecutorTest {
     @Test
     public void shouldBeFailureIfFetchConfigNotValid() {
         Map<String, String> mockVariables = mockEnvironmentVariables.with(AWS_ACCESS_KEY_ID, "").build();
+        TaskExecutionContext mockContext = mockContext(mockVariables);
+        FetchConfig fetchConfig = spy(new FetchConfig(config, mockContext, new GoEnvironment(new HashMap<String,String>())));
+        doReturn(fetchConfig).when(fetchExecutor).getFetchConfig(any(TaskConfig.class), any(TaskExecutionContext.class));
 
-        ExecutionResult executionResult = fetchExecutor.execute(config, mockContext(mockVariables));
+        ExecutionResult executionResult = fetchExecutor.execute(config, mockContext);
+
         assertFalse(executionResult.isSuccessful());
         assertThat(executionResult.getMessagesForDisplay(), is("[AWS_ACCESS_KEY_ID environment variable not present]"));
     }

--- a/publish/src/main/java/com/indix/gocd/s3publish/PublishExecutor.java
+++ b/publish/src/main/java/com/indix/gocd/s3publish/PublishExecutor.java
@@ -39,7 +39,7 @@ public class PublishExecutor implements TaskExecutor {
 
     @Override
     public ExecutionResult execute(TaskConfig config, final TaskExecutionContext context) {
-        final GoEnvironment env = new GoEnvironment();
+        final GoEnvironment env = getGoEnvironment();
         env.putAll(context.environment().asMap());
         if (env.isAbsent(AWS_USE_IAM_ROLE)) {
             if (env.isAbsent(AWS_ACCESS_KEY_ID)) return envNotFound(AWS_ACCESS_KEY_ID);
@@ -101,6 +101,10 @@ public class PublishExecutor implements TaskExecutor {
     /*
         Made public only for tests
      */
+    public GoEnvironment getGoEnvironment() {
+        return new GoEnvironment();
+    }
+
     public AmazonS3Client s3Client(GoEnvironment env) {
         AmazonS3Client client = null;
         if (env.has(AWS_USE_IAM_ROLE)) {

--- a/publish/src/test/java/com/indix/gocd/s3publish/PublishExecutorTest.java
+++ b/publish/src/test/java/com/indix/gocd/s3publish/PublishExecutorTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,6 +45,7 @@ public class PublishExecutorTest {
                 .with("GO_TRIGGER_USER", "Krishna");
 
         publishExecutor = spy(new PublishExecutor());
+        doReturn(new GoEnvironment(new HashMap<String,String>())).when(publishExecutor).getGoEnvironment();
     }
 
     @Test

--- a/utils/src/main/java/com/indix/gocd/utils/GoEnvironment.java
+++ b/utils/src/main/java/com/indix/gocd/utils/GoEnvironment.java
@@ -19,13 +19,19 @@ public class GoEnvironment {
     private Map<String, String> environment = new HashMap<String, String>();
 
     public GoEnvironment() {
-        this.environment.putAll(System.getenv());
+        this(System.getenv());
+    }
+
+    public GoEnvironment(Map<String, String> defaultEnvironment) {
+        this.environment.putAll(defaultEnvironment);
     }
 
     public GoEnvironment putAll(Map<String, String> existing) {
         environment.putAll(existing);
         return this;
     }
+
+    public Map<String,String> asMap() { return environment; }
 
     public String get(String name) {
         return environment.get(name);

--- a/utils/src/test/java/com/indix/gocd/utils/GoEnvironmentTest.java
+++ b/utils/src/test/java/com/indix/gocd/utils/GoEnvironmentTest.java
@@ -3,6 +3,7 @@ package com.indix.gocd.utils;
 import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.util.Map;
@@ -36,6 +37,13 @@ public class GoEnvironmentTest {
     @Test
     public void shouldGenerateArtifactLocationTemplate() {
         assertThat(goEnvironment.artifactsLocationTemplate(), is("s3-publish-test/build-and-publish/publish/20.1"));
+    }
+
+    @Test
+    public void shouldReturnAsMap() {
+        for(Map.Entry<String, String> entry : mockEnvironment.entrySet()) {
+            assertEquals(entry.getValue(), goEnvironment.asMap().get(entry.getKey()));
+        }
     }
 
     @Test


### PR DESCRIPTION
This PR is for Issue #24.  Note this is a breaking change for the use of environment variable AWS_USE_IAM_ROLE to turn on the use of IAM role.  The value of the variable now has to be a valid Boolean truthful value ('True', 'On', or 'Yes') for the use of IAM role to be enabled.  A value of 'False','Off', or 'No' will disable the use of IAM role, which can be a requirement for certain agents that are either not in AWS or for whatever reason do not have the appropriate role and you have to use access keys instead.  

We've also added unit tests to cover this usage (and the use of AWS_USE_IAM_ROLE variable in general).  To enable executing of such tests in our environment, we've also mocked out the system environment variables in tests by parameterizing the environment hashmap in GoEnvironment.java (originally it was hard-coded to System.getenv(), so system environment variables could be polluting the tests).