### PR TITLE
Features/issue29 source label does not reflect upstream pipeline label

### DIFF
--- a/material/src/main/java/com/indix/gocd/s3material/plugin/S3PackageMaterialPoller.java
+++ b/material/src/main/java/com/indix/gocd/s3material/plugin/S3PackageMaterialPoller.java
@@ -1,6 +1,7 @@
 package com.indix.gocd.s3material.plugin;
 
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.util.StringUtils;
 import com.indix.gocd.s3material.config.S3PackageMaterialConfiguration;
 import com.indix.gocd.models.Artifact;
 import com.indix.gocd.models.Revision;
@@ -17,9 +18,12 @@ public class S3PackageMaterialPoller implements PackageMaterialPoller {
     @Override
     public PackageRevision getLatestRevision(PackageConfiguration packageConfiguration, RepositoryConfiguration repositoryConfiguration) {
         String s3Bucket = repositoryConfiguration.get(S3PackageMaterialConfiguration.S3_BUCKET).getValue();
-        S3ArtifactStore artifactStore = new S3ArtifactStore(s3Client(), s3Bucket);
+        S3ArtifactStore artifactStore = s3ArtifactStore(s3Bucket);
         RevisionStatus revision = artifactStore.getLatest(s3Client(), artifact(packageConfiguration));
-        return new PackageRevision(revision.revision.getRevision(), revision.lastModified, revision.user, "", revision.tracebackUrl);
+        return new PackageRevision(revision.revision.getRevision(), revision.lastModified, revision.user,
+                    String.format("Original revision number: %s",
+                    StringUtils.isNullOrEmpty(revision.revisionLabel) ? "unavailable" : revision.revisionLabel),
+                    revision.tracebackUrl);
     }
 
     @Override
@@ -38,7 +42,7 @@ public class S3PackageMaterialPoller implements PackageMaterialPoller {
     @Override
     public Result checkConnectionToRepository(RepositoryConfiguration repositoryConfiguration) {
         String s3Bucket = repositoryConfiguration.get(S3PackageMaterialConfiguration.S3_BUCKET).getValue();
-        S3ArtifactStore artifactStore = new S3ArtifactStore(s3Client(), s3Bucket);
+        S3ArtifactStore artifactStore = s3ArtifactStore(s3Bucket);
         if(artifactStore.bucketExists()){
             return ExecutionResult.success("Success");
         }else{
@@ -49,7 +53,7 @@ public class S3PackageMaterialPoller implements PackageMaterialPoller {
     @Override
     public Result checkConnectionToPackage(PackageConfiguration packageConfiguration, RepositoryConfiguration repositoryConfiguration) {
         String s3Bucket = repositoryConfiguration.get(S3PackageMaterialConfiguration.S3_BUCKET).getValue();
-        S3ArtifactStore artifactStore = new S3ArtifactStore(s3Client(), s3Bucket);
+        S3ArtifactStore artifactStore = s3ArtifactStore(s3Bucket);
         String prefix = artifact(packageConfiguration).prefix();
         if(artifactStore.exists(s3Bucket, prefix))
             return ExecutionResult.success("Success");
@@ -65,6 +69,10 @@ public class S3PackageMaterialPoller implements PackageMaterialPoller {
         // If not, finally, very insecure way, it tries to fetch from the internal metadata service that each
         // instance comes with(if its exposed).
         return new AmazonS3Client();
+    }
+
+    public S3ArtifactStore s3ArtifactStore(String s3Bucket) {
+        return new S3ArtifactStore(s3Client(), s3Bucket);
     }
 
     private Artifact artifact(PackageConfiguration packageConfig) {

--- a/material/src/test/scala/material/plugin/config/S3PackageMaterialPollerSpec.scala
+++ b/material/src/test/scala/material/plugin/config/S3PackageMaterialPollerSpec.scala
@@ -1,0 +1,77 @@
+package material.plugin.config
+
+import java.util.Date
+
+import com.amazonaws.services.s3.AmazonS3Client
+import com.indix.gocd.models.{Revision, RevisionStatus, Artifact}
+import com.indix.gocd.s3material.config.{S3PackageMaterialConfiguration}
+import com.indix.gocd.s3material.plugin.S3PackageMaterialPoller
+import com.indix.gocd.utils.store.S3ArtifactStore
+import com.thoughtworks.go.plugin.api.material.packagerepository.{PackageConfiguration, RepositoryConfiguration, PackageMaterialProperty}
+import org.mockito.Matchers
+import org.scalatest.{WordSpec}
+import org.scalatest.mock.MockitoSugar
+import org.mockito.Mockito._
+
+class S3PackageMaterialPollerSpec extends WordSpec with MockitoSugar  {
+
+  val sut = spy(new S3PackageMaterialPoller());
+  val repoConfig = new RepositoryConfiguration();
+  repoConfig.add(new PackageMaterialProperty(S3PackageMaterialConfiguration.S3_BUCKET, "S3 Bucket"));
+  val mockS3ArtifactStore = mock[S3ArtifactStore];
+  doReturn(mockS3ArtifactStore).when(sut).s3ArtifactStore("S3 Bucket");
+
+  val packageConfig = new PackageConfiguration();
+  packageConfig.add(new PackageMaterialProperty(S3PackageMaterialConfiguration.PIPELINE_NAME, "Pipeline"));
+  packageConfig.add(new PackageMaterialProperty(S3PackageMaterialConfiguration.STAGE_NAME, "Stage"));
+  packageConfig.add(new PackageMaterialProperty(S3PackageMaterialConfiguration.JOB_NAME, "Job"));
+
+  "A package material poller, when checking connection to repository" when {
+    " the bucket is found " should {
+      "return success" in {
+        doReturn(true).when(mockS3ArtifactStore).bucketExists();
+        val result = sut.checkConnectionToRepository(repoConfig);
+
+        assert(result.isSuccessful() == true);
+      }
+    }
+
+    "the bucket is not found" should {
+      "return failure" in {
+        doReturn(false).when(mockS3ArtifactStore).bucketExists();
+
+        val result = sut.checkConnectionToRepository(repoConfig);
+
+        assert(result.isSuccessful() == false);
+      }
+    }
+  }
+
+
+  "A package material poller" when {
+    "getting latest revision" should {
+      "include original revision label if it exists" in {
+
+        when(mockS3ArtifactStore.getLatest(Matchers.any[AmazonS3Client], Matchers.any[Artifact])).thenReturn(
+          new RevisionStatus(new Revision("2.1"),new Date(), "url", "user", "3.1")
+        );
+
+        val result = sut.getLatestRevision(packageConfig, repoConfig);
+
+        assert(result.getRevisionComment().equals("Original revision number: 3.1"));
+      }
+
+      "say the original revision label is unavailable if it doesn't exist" in {
+
+        when(mockS3ArtifactStore.getLatest(Matchers.any[AmazonS3Client], Matchers.any[Artifact])).thenReturn(
+          new RevisionStatus(new Revision("2.1"),new Date(), "url", "user")
+        );
+
+        val result = sut.getLatestRevision(packageConfig, repoConfig);
+
+        assert(result.getRevisionComment().equals("Original revision number: unavailable"));
+
+      }
+    }
+  }
+}

--- a/publish/src/main/java/com/indix/gocd/s3publish/PublishExecutor.java
+++ b/publish/src/main/java/com/indix/gocd/s3publish/PublishExecutor.java
@@ -142,6 +142,7 @@ public class PublishExecutor implements TaskExecutor {
         objectMetadata.addUserMetadata(METADATA_USER, user);
         objectMetadata.addUserMetadata(METADATA_TRACEBACK_URL, tracebackUrl);
         objectMetadata.addUserMetadata(COMPLETED, COMPLETED);
+        objectMetadata.addUserMetadata(GO_PIPELINE_LABEL, env.get(GO_PIPELINE_LABEL));
         return objectMetadata;
     }
 

--- a/publish/src/test/java/com/indix/gocd/s3publish/PublishExecutorTest.java
+++ b/publish/src/test/java/com/indix/gocd/s3publish/PublishExecutorTest.java
@@ -42,6 +42,7 @@ public class PublishExecutorTest {
                 .with("GO_PIPELINE_COUNTER", "pipelineCounter")
                 .with("GO_STAGE_COUNTER", "stageCounter")
                 .with("GO_SERVER_URL", "http://localhost:8153/go")
+                .with(GO_PIPELINE_LABEL, "1.2.3")
                 .with("GO_TRIGGER_USER", "Krishna");
 
         publishExecutor = spy(new PublishExecutor());
@@ -154,6 +155,7 @@ public class PublishExecutorTest {
                 .with(METADATA_USER, "Krishna")
                 .with(METADATA_TRACEBACK_URL, "http://go.server:8153/go/tab/build/detail/pipeline/pipelineCounter/stage/stageCounter/job")
                 .with(COMPLETED, COMPLETED)
+                .with(GO_PIPELINE_LABEL, "1.2.3")
                 .build();
         assertThat(metadataPutRequest.getMetadata().getUserMetadata(), is(expectedUserMetadata));
         assertThat(metadataPutRequest.getKey(), is("pipeline/stage/job/pipelineCounter.stageCounter/"));

--- a/utils/src/main/java/com/indix/gocd/models/ResponseMetadataConstants.java
+++ b/utils/src/main/java/com/indix/gocd/models/ResponseMetadataConstants.java
@@ -5,4 +5,5 @@ public class ResponseMetadataConstants {
     public static final String USER = "user";
     public static final String REVISION_COMMENT = "revision_comment";
     public static final String COMPLETED = "completed";
+    public static final String GO_PIPELINE_LABEL = "go_pipeline_label";
 }

--- a/utils/src/main/java/com/indix/gocd/models/Revision.java
+++ b/utils/src/main/java/com/indix/gocd/models/Revision.java
@@ -46,7 +46,4 @@ public class Revision implements Comparable {
         return revision;
     }
 
-    public void setRevision(String revision) {
-        this.revision = revision;
-    }
 }

--- a/utils/src/main/java/com/indix/gocd/models/RevisionStatus.java
+++ b/utils/src/main/java/com/indix/gocd/models/RevisionStatus.java
@@ -7,11 +7,17 @@ public class RevisionStatus {
     public Date lastModified;
     public String tracebackUrl;
     public String user;
+    public String revisionLabel;
 
     public RevisionStatus(Revision revision, Date lastModified, String tracebackUrl, String user) {
+        this(revision, lastModified, tracebackUrl, user, "");
+        }
+
+    public RevisionStatus(Revision revision, Date lastModified, String tracebackUrl, String user, String revisionLabel) {
         this.revision = revision;
         this.lastModified = lastModified;
         this.tracebackUrl = tracebackUrl;
         this.user = user;
+        this.revisionLabel = revisionLabel;
     }
 }

--- a/utils/src/main/java/com/indix/gocd/utils/Constants.java
+++ b/utils/src/main/java/com/indix/gocd/utils/Constants.java
@@ -20,4 +20,5 @@ public class Constants {
     public static final String STORAGE_CLASS_RRS = "rrs";
     public static final String STORAGE_CLASS_GLACIER = "glacier";
 
+    public static final String GO_PIPELINE_LABEL = "GO_PIPELINE_LABEL";
 }

--- a/utils/src/main/java/com/indix/gocd/utils/store/S3ArtifactStore.java
+++ b/utils/src/main/java/com/indix/gocd/utils/store/S3ArtifactStore.java
@@ -180,7 +180,10 @@ public class S3ArtifactStore {
             Map<String, String> userMetadata = metadata.getUserMetadata();
             String tracebackUrl = userMetadata.get(ResponseMetadataConstants.TRACEBACK_URL);
             String user = userMetadata.get(ResponseMetadataConstants.USER);
-            return new RevisionStatus(recent, metadata.getLastModified(), tracebackUrl, user);
+            String revisionLabel = userMetadata.containsKey(ResponseMetadataConstants.GO_PIPELINE_LABEL) ?
+                    userMetadata.get(ResponseMetadataConstants.GO_PIPELINE_LABEL)
+                    : "";
+            return new RevisionStatus(recent, metadata.getLastModified(), tracebackUrl, user, revisionLabel);
         }
         return null;
     }


### PR DESCRIPTION
Addresses issue #29: Include the original pipeline label value into the S3 object metadata, then pull this information as the revision comment.